### PR TITLE
RFC 5545 compliance: parsing, formatting, and tests

### DIFF
--- a/Sources/RRuleKit/Documentation.docc/Documentation.md
+++ b/Sources/RRuleKit/Documentation.docc/Documentation.md
@@ -37,6 +37,12 @@ Each feature is optimized for performance and adheres to the rules and constrain
   - Supports both UTC and local time zone representations.
   - Includes `TZID` for local times.
 
+- **Enforced RFC 5545 rules**:
+  - FREQ is required (exactly once, any position); keys and values are case-insensitive.
+  - Input is unfolded (CRLF/LF + space removed) before parsing; optional line folding when formatting.
+  - WKST is accepted when parsing and optionally emitted when formatting; SECONDLY is not supported.
+  - COUNT and UNTIL are mutually exclusive; duplicate keys cause parse failure.
+
 ## Topics
 
 ### Essentials

--- a/Sources/RRuleKit/Documentation.docc/FormattingRFC5545.md
+++ b/Sources/RRuleKit/Documentation.docc/FormattingRFC5545.md
@@ -41,3 +41,21 @@ let rfcString = formatter.format(rrule)
 print(rfcString)
 // Output: "FREQ=WEEKLY;BYDAY=MO,FR"
 ```
+
+## Format Options
+
+- **foldLongLines**: When `true`, the formatted string is folded so no line exceeds 75 octets (RFC 5545 Section 3.1). Continuation lines are introduced with CRLF + SPACE. Default is `false`.
+- **emitWKST**: When `true`, the formatter appends `;WKST=MO` for RECUR compliance (default week start). WKST is not stored in `RecurrenceRule`. Default is `false`.
+
+Example:
+
+```swift
+let formatter = RecurrenceRuleRFC5545FormatStyle(calendar: .current, foldLongLines: true, emitWKST: true)
+let rfcString = formatter.format(rrule)
+```
+
+## Notes
+
+- Output order follows RFC 5545: FREQ first, then COUNT or UNTIL (if present), INTERVAL, then BY* parts in a fixed order, optionally WKST.
+- Date and date-time values in UNTIL are formatted per RFC 5545 (UTC with Z, or TZID for local time).
+- Time components default to midnight when omitted.

--- a/Sources/RRuleKit/Documentation.docc/ParsingRFC5545.md
+++ b/Sources/RRuleKit/Documentation.docc/ParsingRFC5545.md
@@ -10,7 +10,7 @@ Parsing functionality allows conversion of strings like:
 FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=2;COUNT=10
 ```
 
-into structured `Calendar.RecurrenceRule objects`.
+into structured `Calendar.RecurrenceRule` objects.
 
 ## Example
 
@@ -21,16 +21,25 @@ import RRuleKit
 let parser = RecurrenceRuleRFC5545FormatStyle(calendar: .current)
 
 do {
-let rfcString = "FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=2;COUNT=10"
-let recurrenceRule = try parser.parse(rfcString)
+  let rfcString = "FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=2;COUNT=10"
+  let recurrenceRule = try parser.parse(rfcString)
   print(recurrenceRule)
 } catch {
   print("Parsing error: \(error)")
 }
 ```
 
-## Notes
+## Key RFC 5545 Parsing Rules
 
-- FREQ is mandatory and must appear first.
-- COUNT and UNTIL cannot coexist in a rule.
+- **FREQ** is mandatory and must appear exactly once. Rule parts may appear in **any order** (e.g. `COUNT=5;FREQ=DAILY` is valid). The key must be exactly `FREQ` (case-insensitive); `FREQUENCY=DAILY` is rejected.
+- **Case-insensitivity**: Property names and enumerated values are case-insensitive (e.g. `freq=daily`, `BYDAY=mo,we`).
+- **Content-line folding**: Input is unfolded before parsing: CRLF or LF followed by a single SPACE or HTAB is removed, so folded content lines (e.g. from .ics files) parse correctly.
+- **WKST**: The `WKST` rule part is accepted and ignored (Foundation has no week-start API).
+- **COUNT** and **UNTIL** cannot coexist; only one may be specified.
+- **Duplicate keys** cause parsing to fail.
+- **FREQ=SECONDLY** is not supported and will cause parsing to fail.
 - Invalid or unsupported keys will cause parsing to fail.
+
+## Limitations
+
+RFC 5545 errata (e.g. BYDAY with numeric modifiers in combination with BYWEEKNO for YEARLY rules) are not validated by the parser.

--- a/Tests/RRuleKitTests/RecurrenceRuleRFC5545RoundTripTests.swift
+++ b/Tests/RRuleKitTests/RecurrenceRuleRFC5545RoundTripTests.swift
@@ -1,0 +1,104 @@
+//
+//  RecurrenceRuleRFC5545RoundTripTests.swift
+//  RRuleKit
+//
+
+import Testing
+import Foundation
+@testable import RRuleKit
+
+@Suite("Recurrence Rule RFC 5545 Round-Trip Tests")
+struct RecurrenceRuleRFC5545RoundTripTests {
+
+  var calendar: Calendar {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = .gmt
+    return cal
+  }
+
+  var style: RecurrenceRuleRFC5545FormatStyle {
+    RecurrenceRuleRFC5545FormatStyle(calendar: calendar)
+  }
+
+  @Test("Parse then format then parse matches original (simple rule)")
+  func roundTripParseFormatParseSimple() throws {
+    let rfcString = "FREQ=DAILY;INTERVAL=2;COUNT=5"
+    let parsed = try style.parse(rfcString)
+    let formatted = style.format(parsed)
+    let reparsed = try style.parse(formatted)
+    #expect(parsed == reparsed)
+  }
+
+  @Test("Parse then format then parse matches original (UNTIL date-only)")
+  func roundTripParseFormatParseUntilDate() throws {
+    let rfcString = "FREQ=DAILY;UNTIL=20250111"
+    let parsed = try style.parse(rfcString)
+    let formatted = style.format(parsed)
+    let reparsed = try style.parse(formatted)
+    #expect(parsed.end == reparsed.end)
+    #expect(parsed.frequency == reparsed.frequency)
+  }
+
+  @Test("Parse then format then parse matches original (UNTIL date-time UTC)")
+  func roundTripParseFormatParseUntilDateTimeUTC() throws {
+    let rfcString = "FREQ=DAILY;UNTIL=20250111T235959Z"
+    let parsed = try style.parse(rfcString)
+    let formatted = style.format(parsed)
+    let reparsed = try style.parse(formatted)
+    #expect(parsed.end == reparsed.end)
+  }
+
+  /// Audit Phase 3.1: round-trip must cover UNTIL with TZID.
+  @Test("Parse then format then parse matches original (UNTIL date-time with TZID)")
+  func roundTripParseFormatParseUntilWithTzid() throws {
+    let tz = try #require(TimeZone(identifier: "America/New_York"))
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = tz
+    let styleWithTz = RecurrenceRuleRFC5545FormatStyle(calendar: cal)
+    let rfcString = "FREQ=DAILY;UNTIL=TZID=America/New_York:20250111T235959"
+    let parsed = try styleWithTz.parse(rfcString)
+    let formatted = styleWithTz.format(parsed)
+    let reparsed = try styleWithTz.parse(formatted)
+    #expect(parsed.end == reparsed.end)
+    #expect(parsed.frequency == reparsed.frequency)
+  }
+
+  @Test("Parse then format then parse matches original (rule with several BY* parts)")
+  func roundTripParseFormatParseWithByParts() throws {
+    let rfcString = "FREQ=MONTHLY;BYDAY=MO,TU;BYMONTH=1,6;BYSETPOS=1,-1;COUNT=5"
+    let parsed = try style.parse(rfcString)
+    let formatted = style.format(parsed)
+    let reparsed = try style.parse(formatted)
+    #expect(parsed == reparsed)
+  }
+
+  @Test("Format then parse then format matches original (simple rule)")
+  func roundTripFormatParseFormatSimple() throws {
+    let rrule = Calendar.RecurrenceRule(
+      calendar: calendar,
+      frequency: .weekly,
+      interval: 1,
+      weekdays: [.every(.monday), .every(.friday)]
+    )
+    let formatted = style.format(rrule)
+    let parsed = try style.parse(formatted)
+    let reformatted = style.format(parsed)
+    #expect(formatted == reformatted)
+  }
+
+  @Test("Format then parse then format matches original (rule with UNTIL and BYDAY)")
+  func roundTripFormatParseFormatWithUntilAndByDay() throws {
+    let components = DateComponents(calendar: calendar, year: 2025, month: 6, day: 15)
+    let endDate = try #require(components.date)
+    let rrule = Calendar.RecurrenceRule(
+      calendar: calendar,
+      frequency: .weekly,
+      end: .afterDate(endDate),
+      weekdays: [.every(.monday), .nth(1, .wednesday)]
+    )
+    let formatted = style.format(rrule)
+    let parsed = try style.parse(formatted)
+    let reformatted = style.format(parsed)
+    #expect(formatted == reformatted)
+  }
+}


### PR DESCRIPTION
great project.  Thank you for sharing.

I make some enhancements to align tighter to the RFC implementation because I needed to interoperate with another rrule package https://github.com/jkbrzt/rrule 

All of my changes include test coverage
Let me know if you requires upstream changes to merge it into the mainline. 

---

Changelog
Parsing (RFC 5545–aligned)
- Rule part names and values are case-insensitive (e.g. FREQ, BYDAY).
- Parts can appear in any order; exactly one FREQ is required (exact key).
- Content lines are unfolded on input (CRLF/LF + leading space/HTAB).
- WKST is accepted (not stored); BYSECOND allows 0–60 (leap second); UNTIL hour 24 is normalized to next day 00:00.

Formatting
- Optional line folding at 75 octets (foldLongLines) and optional WKST=MO output (emitWKST) so generated strings comply with RFC 5545 line length and WKST.

Safety
- Replaced force unwraps in buffer resize and date handling with guards/nil‑coalescing to avoid crashes on malformed or edge-case input.

Tests
- Parse tests: case-insensitivity, arbitrary part order, key rules (FREQUENCY vs FREQ, SECONDLY rejected, duplicate keys), unfolding, WKST, BYSECOND=60, and parse failure as NSError with expected domain/code.
- Format tests: folding, emitWKST, and large-rule output checked semantically.
- Round-trip tests: parse→format→parse and format→parse→format, including UNTIL (date, UTC, TZID) and BY*/BYDAY/TZID.

Docs
- Docs and README updated with RFC 5545 parsing/formatting rules, options, and limitations.